### PR TITLE
fix: remove custom created_at field, use Appwrite's built-in $createdAt

### DIFF
--- a/apps/web/app/api/cash-logs/route.ts
+++ b/apps/web/app/api/cash-logs/route.ts
@@ -115,11 +115,10 @@ export async function POST(request: Request) {
       status: "draft",
       source: "text",
       isIncome: body.isIncome ?? false,
-      parsed_items: "[]",
-      created_at: new Date().toISOString()
+      parsed_items: "[]"
     };
 
-    await serverClient.databases.createDocument(
+    const created = await serverClient.databases.createDocument(
       serverClient.databaseId,
       "cash_logs",
       logId,
@@ -135,7 +134,7 @@ export async function POST(request: Request) {
       source: logDoc.source,
       isIncome: logDoc.isIncome,
       parsedItems: null,
-      createdAt: logDoc.created_at
+      createdAt: created.$createdAt
     });
   } catch (error) {
     console.error("Failed to create cash log:", error);

--- a/apps/web/scripts/appwrite-schema-cash-logs.mjs
+++ b/apps/web/scripts/appwrite-schema-cash-logs.mjs
@@ -31,8 +31,8 @@ const collection = {
     { type: "string", key: "status", size: 20, required: true },
     { type: "string", key: "source", size: 40, required: true },
     { type: "boolean", key: "isIncome", required: true },
-    { type: "string", key: "parsed_items", size: 10000, required: true },
-    { type: "string", key: "created_at", size: 40, required: true }
+    { type: "string", key: "parsed_items", size: 10000, required: true }
+    // Note: We use Appwrite's built-in $createdAt instead of a custom created_at field
   ]
 };
 


### PR DESCRIPTION
The cash_logs collection was failing because it tried to set a 'created_at' attribute that doesn't exist in the user's Appwrite schema. Since Appwrite automatically provides $createdAt on all documents, we don't need a custom field.

Changes:
- Remove created_at from document creation in POST /api/cash-logs
- Use created.$createdAt from Appwrite response instead
- Update schema script to remove created_at attribute