### PR TITLE
fix: correct timezone bugs in getCurrentMonth and buildMonthOptions

### DIFF
--- a/apps/web/app/(shell)/cash/page.tsx
+++ b/apps/web/app/(shell)/cash/page.tsx
@@ -42,24 +42,40 @@ async function getCategories() {
 }
 
 function getCurrentMonth() {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  return `${year}-${month}`;
+  // Use ISO date string to avoid timezone issues
+  const isoDate = new Date().toISOString().split("T")[0]; // "YYYY-MM-DD"
+  return isoDate.substring(0, 7); // "YYYY-MM"
 }
 
 function buildMonthOptions(count = 6) {
   const options: { value: string; label: string }[] = [];
-  const today = new Date();
+  // Get current month in YYYY-MM format
+  const currentMonth = getCurrentMonth();
+  const [year, month] = currentMonth.split("-").map(Number);
+
   for (let i = 0; i < count; i++) {
-    const date = new Date(today.getFullYear(), today.getMonth() - i, 1);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
+    // Calculate year and month offset
+    let targetYear = year;
+    let targetMonth = month - i;
+
+    // Handle year rollover
+    while (targetMonth < 1) {
+      targetMonth += 12;
+      targetYear -= 1;
+    }
+
+    const monthStr = String(targetMonth).padStart(2, "0");
+    const value = `${targetYear}-${monthStr}`;
+
+    // Create date for formatting label (using UTC to avoid timezone issues)
+    const date = new Date(Date.UTC(targetYear, targetMonth - 1, 1));
     const label = date.toLocaleDateString("en-AU", {
       month: "short",
-      year: "numeric"
+      year: "numeric",
+      timeZone: "UTC"
     });
-    options.push({ value: `${year}-${month}`, label });
+
+    options.push({ value, label });
   }
   return options;
 }


### PR DESCRIPTION
The page.tsx functions were using getFullYear()/getMonth() which are affected by server timezone, causing queries to use wrong months.

For example, on Jan 1 2026 UTC in PST timezone:
- Server local: Dec 31 2025
- getCurrentMonth() returned: "2025-12"
- But entries saved with: "2026-01"
- Result: No entries found!

Fixed by:
- getCurrentMonth(): Use toISOString() to get UTC date, extract YYYY-MM
- buildMonthOptions(): Manual month arithmetic + UTC date for labels

This ensures month values used for querying match the month values stored in the database.