### PR TITLE
Add toggle to hide sensitive numbers on dashboard

### DIFF
--- a/apps/web/app/(shell)/TopbarWithUser.tsx
+++ b/apps/web/app/(shell)/TopbarWithUser.tsx
@@ -3,9 +3,11 @@
 import { useMemo } from "react";
 import { Topbar } from "@financelab/ui";
 import { useAuth } from "../../lib/auth-context";
+import { useNumberVisibility } from "../../lib/number-visibility-context";
 
 export default function TopbarWithUser() {
   const { user } = useAuth();
+  const { isVisible, toggleVisibility } = useNumberVisibility();
 
   const userLabel = useMemo(() => {
     if (!user) {
@@ -15,5 +17,11 @@ export default function TopbarWithUser() {
     return label ? `Signed in as ${label}` : "Signed in";
   }, [user]);
 
-  return <Topbar userLabel={userLabel} />;
+  return (
+    <Topbar
+      userLabel={userLabel}
+      onToggleNumberVisibility={toggleVisibility}
+      numbersVisible={isVisible}
+    />
+  );
 }

--- a/apps/web/app/(shell)/assets/AssetsClient.tsx
+++ b/apps/web/app/(shell)/assets/AssetsClient.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { Card, SectionHead } from "@financelab/ui";
 import type { AssetOverview, AssetItem, AssetHistoryEntry } from "../../../lib/data";
+import { useNumberVisibility } from "../../../lib/number-visibility-context";
+import { maskCurrencyValue } from "../../../lib/data";
 
 type AssetsClientProps = {
   overview: AssetOverview;
@@ -103,6 +105,20 @@ function formatValueWithAud(value: string, audValue: string, currency: string) {
   return `${value} (${audValue})`;
 }
 
+function formatValueWithAudMasked(
+  value: string,
+  audValue: string,
+  currency: string,
+  isVisible: boolean
+) {
+  const maskedValue = maskCurrencyValue(value, isVisible);
+  if (!currency || currency.toUpperCase() === "AUD") {
+    return maskedValue;
+  }
+  const maskedAudValue = maskCurrencyValue(audValue, isVisible);
+  return `${maskedValue} (${maskedAudValue})`;
+}
+
 function buildOwnerLabel(owner: string) {
   return owner || "Joint";
 }
@@ -122,6 +138,7 @@ function parseCurrencyInput(value: string) {
 }
 
 export default function AssetsClient({ overview }: AssetsClientProps) {
+  const { isVisible } = useNumberVisibility();
   const [overviewState, setOverviewState] = useState<AssetOverview>(overview);
   const {
     categories,
@@ -562,7 +579,7 @@ export default function AssetsClient({ overview }: AssetsClientProps) {
       <div className="hero">
         <div>
           <div className="eyebrow">Net Worth</div>
-          <div className="hero-value">{netWorthFormatted}</div>
+          <div className="hero-value">{maskCurrencyValue(netWorthFormatted, isVisible)}</div>
           <div className="hero-sub">{heroSub}</div>
         </div>
       <div className="hero-meta">
@@ -578,7 +595,7 @@ export default function AssetsClient({ overview }: AssetsClientProps) {
           <Card
             key={category.type}
             title={category.label}
-            value={category.formattedValue}
+            value={maskCurrencyValue(category.formattedValue, isVisible)}
             sub={category.subLabel}
             tone={category.tone}
           />
@@ -786,10 +803,11 @@ export default function AssetsClient({ overview }: AssetsClientProps) {
                           <span>{asset.name}</span>
                       <span>{buildOwnerLabel(asset.owner)}</span>
                       <span>
-                        {formatValueWithAud(
+                        {formatValueWithAudMasked(
                           asset.formattedValue,
                           asset.formattedAudValue,
-                          asset.currency
+                          asset.currency,
+                          isVisible
                         )}
                       </span>
                           <span>{asset.lastUpdatedLabel}</span>
@@ -1066,10 +1084,11 @@ export default function AssetsClient({ overview }: AssetsClientProps) {
                                     <span>{entry.name}</span>
                                     <span>{entry.typeLabel}</span>
                                     <span>
-                                      {formatValueWithAud(
+                                      {formatValueWithAudMasked(
                                         entry.formattedValue,
                                         entry.formattedAudValue,
-                                        entry.currency
+                                        entry.currency,
+                                        isVisible
                                       )}
                                     </span>
                                     <span>{entry.recordedLabel}</span>
@@ -1125,10 +1144,11 @@ export default function AssetsClient({ overview }: AssetsClientProps) {
                 <span>{asset.typeLabel}</span>
                 <span>{buildOwnerLabel(asset.owner)}</span>
                 <span>
-                  {formatValueWithAud(
+                  {formatValueWithAudMasked(
                     asset.formattedValue,
                     asset.formattedAudValue,
-                    asset.currency
+                    asset.currency,
+                    isVisible
                   )}
                 </span>
                 <span>{asset.lastUpdatedLabel}</span>

--- a/apps/web/app/(shell)/dashboard/DashboardClient.tsx
+++ b/apps/web/app/(shell)/dashboard/DashboardClient.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import {
+  Card,
+  DonutChart,
+  SectionHead
+} from "@financelab/ui";
+import { Suspense } from "react";
+import { useNumberVisibility } from "../../../lib/number-visibility-context";
+import { maskCurrencyValue } from "../../../lib/data";
+import MonthSelector from "../reports/expenses/MonthSelector";
+import WaterfallDrilldown from "./WaterfallDrilldown";
+import SpendByCategoryControls from "./SpendByCategoryControls";
+
+import type { NetWorthPoint, AssetCategorySummary } from "../../../lib/data";
+
+type DonutSegment = { className: string; value: number };
+type DonutLegend = { label: string; dot: string };
+
+function buildTrendPoints(series: NetWorthPoint[]) {
+  if (series.length < 2) {
+    return "";
+  }
+  const width = 360;
+  const top = 20;
+  const bottom = 120;
+  const height = bottom - top;
+  const values = series.map((point) => point.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const step = width / (series.length - 1);
+
+  return series
+    .map((point, index) => {
+      const x = index * step;
+      const normalized = (point.value - min) / range;
+      const y = bottom - normalized * height;
+      return `${x},${y}`;
+    })
+    .join(" ");
+}
+
+function buildPortfolioSegments(categories: AssetCategorySummary[]) {
+  const byType = new Map(categories.map((category) => [category.type, category]));
+  const valueFor = (type: string) => byType.get(type)?.totalValue ?? 0;
+  const netProperty =
+    valueFor("property") + valueFor("liability") + valueFor("mortgage");
+  const netCash = valueFor("cash") + valueFor("other_liability");
+  const netCategories: AssetCategorySummary[] = [];
+
+  if (netProperty !== 0) {
+    netCategories.push({
+      type: "property_net",
+      label: "Property (net)",
+      totalValue: netProperty,
+      formattedValue: "",
+      subLabel: "",
+      tone: "glow"
+    });
+  }
+
+  if (netCash !== 0) {
+    netCategories.push({
+      type: "cash_net",
+      label: "Cash (net)",
+      totalValue: netCash,
+      formattedValue: "",
+      subLabel: "",
+      tone: "glow"
+    });
+  }
+
+  const excludedTypes = new Set([
+    "property",
+    "liability",
+    "mortgage",
+    "other_liability",
+    "cash"
+  ]);
+
+  for (const category of categories) {
+    if (excludedTypes.has(category.type)) {
+      continue;
+    }
+    netCategories.push(category);
+  }
+
+  const eligible = netCategories
+    .filter((category) => (category.totalValue ?? 0) > 0)
+    .sort((a, b) => (b.totalValue ?? 0) - (a.totalValue ?? 0));
+  const total = eligible.reduce((sum, item) => sum + (item.totalValue ?? 0), 0);
+  if (total <= 0) {
+    return { segments: [], legend: [] };
+  }
+  const top = eligible.slice(0, 3);
+  const otherTotal = eligible
+    .slice(3)
+    .reduce((sum, item) => sum + (item.totalValue ?? 0), 0);
+  const segmentClasses = ["seg-a", "seg-b", "seg-c"];
+  const dotClasses = ["a", "b", "c"];
+  const segments: DonutSegment[] = top.map((item, index) => ({
+    className: segmentClasses[index],
+    value: item.totalValue ?? 0
+  }));
+  const legend: DonutLegend[] = top.map((item, index) => ({
+    label: `${item.label} ${Math.round(((item.totalValue ?? 0) / total) * 100)}%`,
+    dot: dotClasses[index]
+  }));
+
+  if (otherTotal > 0) {
+    segments.push({ className: "seg-d", value: otherTotal });
+    legend.push({
+      label: `Other ${Math.round((otherTotal / total) * 100)}%`,
+      dot: "d"
+    });
+  }
+
+  return { segments, legend };
+}
+
+export default function DashboardClient({
+  assetOverview,
+  breakdown,
+  cashFlow,
+  statCards,
+  availableCategories,
+  selectedSpendCategories,
+  spendTop
+}: any) {
+  const { isVisible } = useNumberVisibility();
+
+  const spendByCategory = breakdown.categories;
+  const filteredSpend = spendByCategory.filter((category: any) =>
+    selectedSpendCategories.includes(category.name)
+  );
+  const sortedSpend = [...filteredSpend].sort(
+    (a: any, b: any) => Math.abs(b.amount) - Math.abs(a.amount)
+  );
+  const spendTotal = filteredSpend.reduce(
+    (sum: number, item: any) => sum + Math.abs(item.amount),
+    0
+  );
+  const topCategories = sortedSpend.slice(0, spendTop);
+  const otherTotal = sortedSpend
+    .slice(spendTop)
+    .reduce((sum: number, item: any) => sum + Math.abs(item.amount), 0);
+  const segmentClasses = ["seg-a", "seg-b", "seg-c", "seg-d", "seg-e", "seg-f"];
+  const dotClasses = ["a", "b", "c", "d", "e", "f"];
+  const spendSegments = topCategories.map((item: any, index: number) => ({
+    className: segmentClasses[index],
+    value: Math.abs(item.amount)
+  }));
+  const spendLegend = topCategories.map((item: any, index: number) => ({
+    label: `${item.name} ${
+      spendTotal ? Math.round((Math.abs(item.amount) / spendTotal) * 100) : 0
+    }%`,
+    dot: dotClasses[index]
+  }));
+  const portfolioSplit = buildPortfolioSegments(assetOverview.categories);
+  const netWorthPoints = buildTrendPoints(assetOverview.netWorthSeries);
+  const hasNetWorthTrend = netWorthPoints.length > 0;
+  const heroSub =
+    assetOverview.lastUpdatedLabel === "No updates yet"
+      ? "No updates yet"
+      : `Last update: ${assetOverview.lastUpdatedLabel}`;
+
+  if (otherTotal > 0 && spendTotal > 0) {
+    const otherPercent = Math.round((otherTotal / spendTotal) * 100);
+    spendSegments.push({ className: "seg-g", value: otherTotal });
+    spendLegend.push({ label: `Other ${otherPercent}%`, dot: "g" });
+  }
+
+  return (
+    <>
+      <SectionHead
+        eyebrow="Dashboard"
+        title="Household Overview"
+        breadcrumbs={[
+          { label: "Home", href: "/dashboard" },
+          { label: "Overview" }
+        ]}
+      />
+      <div className="hero">
+        <div>
+          <div className="eyebrow">Net Worth</div>
+          <div className="hero-value">
+            {maskCurrencyValue(assetOverview.netWorthFormatted, isVisible)}
+          </div>
+          <div className="hero-sub">{heroSub}</div>
+        </div>
+        <div className="hero-meta">
+          <div className="meta-pill">
+            {maskCurrencyValue(breakdown.totalFormatted, isVisible)} spend
+          </div>
+        </div>
+      </div>
+      <div className="dashboard-section">
+        <div className="card-title">Assets snapshot</div>
+        <div className="card-sub">Latest totals by category</div>
+      </div>
+      <div className="grid cards">
+        {assetOverview.categories.map((category: any, index: number) => (
+          <Card
+            key={category.type}
+            title={category.label}
+            value={maskCurrencyValue(category.formattedValue, isVisible)}
+            sub={category.subLabel}
+            tone={category.tone as "glow" | "negative"}
+            className={`card-${index}`}
+          />
+        ))}
+      </div>
+      {statCards.length > 0 ? (
+        <div className="grid cards">
+          {statCards.map((card: any, index: number) => (
+            <Card
+              key={card.title}
+              title={card.title}
+              value={maskCurrencyValue(card.value, isVisible)}
+              sub={card.sub}
+              tone={card.tone as "glow" | "negative"}
+              className={`card-${index}`}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="empty-state">No dashboard stats yet.</div>
+      )}
+      <div className="grid charts">
+        {spendSegments.length > 0 ? (
+          <DonutChart
+            title="Spend by Category"
+            actions={
+              <>
+                <Suspense fallback={<span className="pill">Loading...</span>}>
+                  <MonthSelector
+                    options={breakdown.monthOptions}
+                    selected={breakdown.selectedMonth}
+                    basePath="/dashboard"
+                  />
+                </Suspense>
+                <SpendByCategoryControls
+                  categories={availableCategories}
+                  selectedCategories={selectedSpendCategories}
+                  topCount={spendTop}
+                />
+              </>
+            }
+            segments={spendSegments}
+            legend={spendLegend}
+          />
+        ) : (
+          <article className="card chart">
+            <div className="chart-head">
+              <div className="card-title">Spend by Category</div>
+            </div>
+            <div className="empty-state">No spend data yet.</div>
+          </article>
+        )}
+        {portfolioSplit.segments.length > 0 ? (
+          <DonutChart
+            title="Portfolio Split"
+            segments={portfolioSplit.segments}
+            legend={portfolioSplit.legend}
+          />
+        ) : (
+          <article className="card chart">
+            <div className="chart-head">
+              <div className="card-title">Portfolio Split</div>
+            </div>
+            <div className="empty-state">Add asset snapshots to see the split.</div>
+          </article>
+        )}
+        <article className="card chart wide">
+          <div className="chart-head">
+            <div className="card-title">Net Worth Trend</div>
+          </div>
+          <div className="chart-body">
+            {hasNetWorthTrend ? (
+              <svg viewBox="0 0 360 140" aria-hidden="true">
+                <polyline className="trend" points={netWorthPoints} />
+              </svg>
+            ) : (
+              <div className="empty-state">Add monthly snapshots to see the trend.</div>
+            )}
+          </div>
+        </article>
+        <WaterfallDrilldown cashFlow={cashFlow} />
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(shell)/dashboard/page.tsx
+++ b/apps/web/app/(shell)/dashboard/page.tsx
@@ -1,20 +1,10 @@
 import {
-  Card,
-  DonutChart,
-  SectionHead
-} from "@financelab/ui";
-import {
   getAssetOverview,
   getCashFlowWaterfall,
   getExpenseBreakdown,
   getStatCards
 } from "../../../lib/data";
-import MonthSelector from "../reports/expenses/MonthSelector";
-import WaterfallDrilldown from "./WaterfallDrilldown";
-
-import SpendByCategoryControls from "./SpendByCategoryControls";
-import { Suspense } from "react";
-import type { NetWorthPoint, AssetCategorySummary } from "../../../lib/data";
+import DashboardClient from "./DashboardClient";
 
 type DashboardPageProps = {
   searchParams?: Promise<{
@@ -23,111 +13,6 @@ type DashboardPageProps = {
     spendCategories?: string;
   }>;
 };
-
-type DonutSegment = { className: string; value: number };
-type DonutLegend = { label: string; dot: string };
-
-function buildTrendPoints(series: NetWorthPoint[]) {
-  if (series.length < 2) {
-    return "";
-  }
-  const width = 360;
-  const top = 20;
-  const bottom = 120;
-  const height = bottom - top;
-  const values = series.map((point) => point.value);
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const range = max - min || 1;
-  const step = width / (series.length - 1);
-
-  return series
-    .map((point, index) => {
-      const x = index * step;
-      const normalized = (point.value - min) / range;
-      const y = bottom - normalized * height;
-      return `${x},${y}`;
-    })
-    .join(" ");
-}
-
-function buildPortfolioSegments(categories: AssetCategorySummary[]) {
-  const byType = new Map(categories.map((category) => [category.type, category]));
-  const valueFor = (type: string) => byType.get(type)?.totalValue ?? 0;
-  const netProperty =
-    valueFor("property") + valueFor("liability") + valueFor("mortgage");
-  const netCash = valueFor("cash") + valueFor("other_liability");
-  const netCategories: AssetCategorySummary[] = [];
-
-  if (netProperty !== 0) {
-    netCategories.push({
-      type: "property_net",
-      label: "Property (net)",
-      totalValue: netProperty,
-      formattedValue: "",
-      subLabel: "",
-      tone: "glow"
-    });
-  }
-
-  if (netCash !== 0) {
-    netCategories.push({
-      type: "cash_net",
-      label: "Cash (net)",
-      totalValue: netCash,
-      formattedValue: "",
-      subLabel: "",
-      tone: "glow"
-    });
-  }
-
-  const excludedTypes = new Set([
-    "property",
-    "liability",
-    "mortgage",
-    "other_liability",
-    "cash"
-  ]);
-
-  for (const category of categories) {
-    if (excludedTypes.has(category.type)) {
-      continue;
-    }
-    netCategories.push(category);
-  }
-
-  const eligible = netCategories
-    .filter((category) => (category.totalValue ?? 0) > 0)
-    .sort((a, b) => (b.totalValue ?? 0) - (a.totalValue ?? 0));
-  const total = eligible.reduce((sum, item) => sum + (item.totalValue ?? 0), 0);
-  if (total <= 0) {
-    return { segments: [], legend: [] };
-  }
-  const top = eligible.slice(0, 3);
-  const otherTotal = eligible
-    .slice(3)
-    .reduce((sum, item) => sum + (item.totalValue ?? 0), 0);
-  const segmentClasses = ["seg-a", "seg-b", "seg-c"];
-  const dotClasses = ["a", "b", "c"];
-  const segments: DonutSegment[] = top.map((item, index) => ({
-    className: segmentClasses[index],
-    value: item.totalValue ?? 0
-  }));
-  const legend: DonutLegend[] = top.map((item, index) => ({
-    label: `${item.label} ${Math.round(((item.totalValue ?? 0) / total) * 100)}%`,
-    dot: dotClasses[index]
-  }));
-
-  if (otherTotal > 0) {
-    segments.push({ className: "seg-d", value: otherTotal });
-    legend.push({
-      label: `Other ${Math.round((otherTotal / total) * 100)}%`,
-      dot: "d"
-    });
-  }
-
-  return { segments, legend };
-}
 
 export default async function DashboardPage({ searchParams }: DashboardPageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
@@ -154,159 +39,16 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     Number.isFinite(spendTopRaw) && spendTopRaw > 0
       ? Math.min(Math.round(spendTopRaw), 6)
       : 3;
-  const filteredSpend = spendByCategory.filter((category) =>
-    selectedSpendCategories.includes(category.name)
-  );
-  const sortedSpend = [...filteredSpend].sort(
-    (a, b) => Math.abs(b.amount) - Math.abs(a.amount)
-  );
-  const spendTotal = filteredSpend.reduce(
-    (sum, item) => sum + Math.abs(item.amount),
-    0
-  );
-  const topCategories = sortedSpend.slice(0, spendTop);
-  const otherTotal = sortedSpend
-    .slice(spendTop)
-    .reduce((sum, item) => sum + Math.abs(item.amount), 0);
-  const segmentClasses = ["seg-a", "seg-b", "seg-c", "seg-d", "seg-e", "seg-f"];
-  const dotClasses = ["a", "b", "c", "d", "e", "f"];
-  const spendSegments = topCategories.map((item, index) => ({
-    className: segmentClasses[index],
-    value: Math.abs(item.amount)
-  }));
-  const spendLegend = topCategories.map((item, index) => ({
-    label: `${item.name} ${
-      spendTotal ? Math.round((Math.abs(item.amount) / spendTotal) * 100) : 0
-    }%`,
-    dot: dotClasses[index]
-  }));
-  const portfolioSplit = buildPortfolioSegments(assetOverview.categories);
-  const netWorthPoints = buildTrendPoints(assetOverview.netWorthSeries);
-  const hasNetWorthTrend = netWorthPoints.length > 0;
-  const heroSub =
-    assetOverview.lastUpdatedLabel === "No updates yet"
-      ? "No updates yet"
-      : `Last update: ${assetOverview.lastUpdatedLabel}`;
-
-  if (otherTotal > 0 && spendTotal > 0) {
-    const otherPercent = Math.round((otherTotal / spendTotal) * 100);
-    spendSegments.push({ className: "seg-g", value: otherTotal });
-    spendLegend.push({ label: `Other ${otherPercent}%`, dot: "g" });
-  }
 
   return (
-    <>
-      <SectionHead
-        eyebrow="Dashboard"
-        title="Household Overview"
-        breadcrumbs={[
-          { label: "Home", href: "/dashboard" },
-          { label: "Overview" }
-        ]}
-      />
-      <div className="hero">
-        <div>
-          <div className="eyebrow">Net Worth</div>
-          <div className="hero-value">{assetOverview.netWorthFormatted}</div>
-          <div className="hero-sub">{heroSub}</div>
-        </div>
-        <div className="hero-meta">
-          <div className="meta-pill">{breakdown.totalFormatted} spend</div>
-        </div>
-      </div>
-      <div className="dashboard-section">
-        <div className="card-title">Assets snapshot</div>
-        <div className="card-sub">Latest totals by category</div>
-      </div>
-      <div className="grid cards">
-        {assetOverview.categories.map((category, index) => (
-          <Card
-            key={category.type}
-            title={category.label}
-            value={category.formattedValue}
-            sub={category.subLabel}
-            tone={category.tone as "glow" | "negative"}
-            className={`card-${index}`}
-          />
-        ))}
-      </div>
-      {statCards.length > 0 ? (
-        <div className="grid cards">
-          {statCards.map((card, index) => (
-            <Card
-              key={card.title}
-              title={card.title}
-              value={card.value}
-              sub={card.sub}
-              tone={card.tone as "glow" | "negative"}
-              className={`card-${index}`}
-            />
-          ))}
-        </div>
-      ) : (
-        <div className="empty-state">No dashboard stats yet.</div>
-      )}
-      <div className="grid charts">
-        {spendSegments.length > 0 ? (
-          <DonutChart
-            title="Spend by Category"
-            actions={
-              <>
-                <Suspense fallback={<span className="pill">Loading...</span>}>
-                  <MonthSelector
-                    options={breakdown.monthOptions}
-                    selected={breakdown.selectedMonth}
-                    basePath="/dashboard"
-                  />
-                </Suspense>
-                <SpendByCategoryControls
-                  categories={availableCategories}
-                  selectedCategories={selectedSpendCategories}
-                  topCount={spendTop}
-                />
-              </>
-            }
-            segments={spendSegments}
-            legend={spendLegend}
-          />
-        ) : (
-          <article className="card chart">
-            <div className="chart-head">
-              <div className="card-title">Spend by Category</div>
-            </div>
-            <div className="empty-state">No spend data yet.</div>
-          </article>
-        )}
-        {portfolioSplit.segments.length > 0 ? (
-          <DonutChart
-            title="Portfolio Split"
-            segments={portfolioSplit.segments}
-            legend={portfolioSplit.legend}
-          />
-        ) : (
-          <article className="card chart">
-            <div className="chart-head">
-              <div className="card-title">Portfolio Split</div>
-            </div>
-            <div className="empty-state">Add asset snapshots to see the split.</div>
-          </article>
-        )}
-        <article className="card chart wide">
-          <div className="chart-head">
-            <div className="card-title">Net Worth Trend</div>
-          </div>
-          <div className="chart-body">
-            {hasNetWorthTrend ? (
-              <svg viewBox="0 0 360 140" aria-hidden="true">
-                <polyline className="trend" points={netWorthPoints} />
-              </svg>
-            ) : (
-              <div className="empty-state">Add monthly snapshots to see the trend.</div>
-            )}
-          </div>
-        </article>
-        <WaterfallDrilldown cashFlow={cashFlow} />
-      </div>
-    </>
+    <DashboardClient
+      assetOverview={assetOverview}
+      breakdown={breakdown}
+      cashFlow={cashFlow}
+      statCards={statCards}
+      availableCategories={availableCategories}
+      selectedSpendCategories={selectedSpendCategories}
+      spendTop={spendTop}
+    />
   );
 }

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -5,6 +5,7 @@ import { getNavItems } from "../../lib/data";
 import AuthGate from "./authGate";
 import TopbarWithUser from "./TopbarWithUser";
 import { AuthProvider } from "../../lib/auth-context";
+import { NumberVisibilityProvider } from "../../lib/number-visibility-context";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -18,15 +19,17 @@ export default async function ShellLayout({ children }: ShellLayoutProps) {
 
   return (
     <AuthProvider>
-      <div className="app-shell">
-        <Sidebar navItems={navItems} />
-        <main className="main">
-          <Suspense fallback={<div className="topbar" />}>
-            <TopbarWithUser />
-          </Suspense>
-          <AuthGate>{children}</AuthGate>
-        </main>
-      </div>
+      <NumberVisibilityProvider>
+        <div className="app-shell">
+          <Sidebar navItems={navItems} />
+          <main className="main">
+            <Suspense fallback={<div className="topbar" />}>
+              <TopbarWithUser />
+            </Suspense>
+            <AuthGate>{children}</AuthGate>
+          </main>
+        </div>
+      </NumberVisibilityProvider>
     </AuthProvider>
   );
 }

--- a/apps/web/app/(shell)/reports/MonthlyCloseClient.tsx
+++ b/apps/web/app/(shell)/reports/MonthlyCloseClient.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import { Card, DonutChart, ListRow } from "@financelab/ui";
 import ExpenseCategoryList from "./expenses/ExpenseCategoryList";
 import type { ExpenseBreakdown, MonthlyCloseSummary } from "../../../lib/data";
+import { useNumberVisibility } from "../../../lib/number-visibility-context";
+import { maskCurrencyValue } from "../../../lib/data";
 
 type MonthlyCloseClientProps = {
   summary: MonthlyCloseSummary;
@@ -34,6 +36,7 @@ export default function MonthlyCloseClient({
   summary,
   expenseBreakdown
 }: MonthlyCloseClientProps) {
+  const { isVisible } = useNumberVisibility();
   const router = useRouter();
   const [actionState, setActionState] = useState<ActionState>("idle");
   const [error, setError] = useState<string>("");
@@ -135,19 +138,19 @@ export default function MonthlyCloseClient({
       </div>
 
       <div className="grid cards">
-        <Card title="Income" value={summary.formattedIncomeTotal} sub="Month total" />
-        <Card title="Expenses" value={summary.formattedExpenseTotal} sub="Month total" />
+        <Card title="Income" value={maskCurrencyValue(summary.formattedIncomeTotal, isVisible)} sub="Month total" />
+        <Card title="Expenses" value={maskCurrencyValue(summary.formattedExpenseTotal, isVisible)} sub="Month total" />
         <Card
           title="Transfers Excluded"
-          value={summary.formattedTransferOutflowTotal}
+          value={maskCurrencyValue(summary.formattedTransferOutflowTotal, isVisible)}
           sub="Outflows only"
         />
-        <Card title="Net Worth" value={summary.formattedNetWorthTotal} sub="Month-end" />
+        <Card title="Net Worth" value={maskCurrencyValue(summary.formattedNetWorthTotal, isVisible)} sub="Month-end" />
       </div>
 
       <div className="monthly-close-meta">
-        <div className="meta-pill">Assets {summary.formattedAssetsTotal}</div>
-        <div className="meta-pill">Liabilities {summary.formattedLiabilitiesTotal}</div>
+        <div className="meta-pill">Assets {maskCurrencyValue(summary.formattedAssetsTotal, isVisible)}</div>
+        <div className="meta-pill">Liabilities {maskCurrencyValue(summary.formattedLiabilitiesTotal, isVisible)}</div>
         <div className="meta-pill">Assets use latest recorded values</div>
       </div>
 
@@ -166,7 +169,7 @@ export default function MonthlyCloseClient({
       <details className="report-accordion">
         <summary className="report-accordion-summary">
           <span>Expense detail</span>
-          <span className="report-accordion-meta">{totalFormatted} total</span>
+          <span className="report-accordion-meta">{maskCurrencyValue(totalFormatted, isVisible)} total</span>
         </summary>
         <div className="report-accordion-body">
           {spendByCategory.length > 0 ? (
@@ -174,7 +177,7 @@ export default function MonthlyCloseClient({
               <div className="grid cards">
                 <Card
                   title="Total expenses"
-                  value={totalFormatted}
+                  value={maskCurrencyValue(totalFormatted, isVisible)}
                   sub="Recent activity"
                 />
                 <Card
@@ -207,7 +210,7 @@ export default function MonthlyCloseClient({
                         title={item.name}
                         sub={`${item.count} transactions - ${item.percent}% of spend`}
                         category={`${item.percent}% share`}
-                        amount={item.formattedAmount}
+                        amount={maskCurrencyValue(item.formattedAmount, isVisible)}
                         tone={item.amount >= 0 ? "positive" : "negative"}
                       />
                     ))}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -266,6 +266,17 @@ h3,
   background: rgba(26, 33, 46, 0.6);
 }
 
+.secondary-btn {
+  border-color: var(--border);
+  color: var(--text-primary);
+  background: rgba(26, 33, 46, 0.8);
+}
+
+.secondary-btn:hover {
+  background: rgba(26, 33, 46, 1);
+  border-color: var(--accent);
+}
+
 .pill {
   border-color: var(--border);
   background: rgba(26, 33, 46, 0.6);

--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -642,6 +642,34 @@ function formatSignedCurrency(amount: number, currency = "AUD") {
   return `${sign}${formatCurrencyValue(Math.abs(amount), currency)}`;
 }
 
+export function maskCurrencyValue(formattedValue: string, isVisible: boolean) {
+  if (isVisible) {
+    return formattedValue;
+  }
+
+  // Extract currency symbol and numeric part
+  // For example: "$1,234.56" or "-$1,234.56"
+  const match = formattedValue.match(/^(-?)(\$|[A-Z]{3})\s?([\d,]+\.?\d*)/);
+
+  if (!match) {
+    // If format doesn't match, just show first 2 chars + asterisks
+    return formattedValue.slice(0, 2) + "***";
+  }
+
+  const [, sign, currencySymbol, numericPart] = match;
+
+  // Remove commas and get just the digits
+  const digits = numericPart.replace(/,/g, "");
+
+  // Show first 2 digits and mask the rest
+  if (digits.length <= 2) {
+    return `${sign}${currencySymbol}${digits.slice(0, 2)}***`;
+  }
+
+  const firstTwo = digits.slice(0, 2);
+  return `${sign}${currencySymbol}${firstTwo}***`;
+}
+
 function normalizeAssetKey(value: string) {
   return value.trim().toLowerCase();
 }

--- a/apps/web/lib/number-visibility-context.tsx
+++ b/apps/web/lib/number-visibility-context.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface NumberVisibilityState {
+  isVisible: boolean;
+  toggleVisibility: () => void;
+}
+
+const NumberVisibilityContext = createContext<NumberVisibilityState | undefined>(
+  undefined
+);
+
+export function NumberVisibilityProvider({ children }: { children: ReactNode }) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = () => {
+    setIsVisible((prev) => !prev);
+  };
+
+  return (
+    <NumberVisibilityContext.Provider value={{ isVisible, toggleVisibility }}>
+      {children}
+    </NumberVisibilityContext.Provider>
+  );
+}
+
+export function useNumberVisibility() {
+  const context = useContext(NumberVisibilityContext);
+  if (context === undefined) {
+    throw new Error(
+      "useNumberVisibility must be used within a NumberVisibilityProvider"
+    );
+  }
+  return context;
+}

--- a/packages/ui/src/components/Topbar.tsx
+++ b/packages/ui/src/components/Topbar.tsx
@@ -32,9 +32,11 @@ function buildMonthOptions(count = 12): MonthOption[] {
 
 type TopbarProps = {
   userLabel?: string;
+  onToggleNumberVisibility?: () => void;
+  numbersVisible?: boolean;
 };
 
-export function Topbar({ userLabel }: TopbarProps) {
+export function Topbar({ userLabel, onToggleNumberVisibility, numbersVisible }: TopbarProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -119,6 +121,16 @@ export function Topbar({ userLabel }: TopbarProps) {
         </div>
       )}
       <div className="topbar-actions">
+        {onToggleNumberVisibility && (
+          <button
+            className="secondary-btn"
+            type="button"
+            onClick={onToggleNumberVisibility}
+            aria-label={numbersVisible ? "Hide numbers" : "Show numbers"}
+          >
+            {numbersVisible ? "👁️ Hide" : "👁️‍🗨️ Show"}
+          </button>
+        )}
         <button className="primary-btn" type="button" onClick={handleImportClick}>
           Import
         </button>


### PR DESCRIPTION
Implements a UI feature to hide/show sensitive financial numbers across the application.
- Numbers show first 2 digits followed by asterisks when hidden
- Toggle button in topbar allows users to switch between hidden/visible states
- Applied to Dashboard, Assets, and Reports pages
- Uses React Context for global state management
- No data security implications - purely a visual/UI feature