### PR TITLE
fix: make ledger default to most recent unclosed month

### DIFF
--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -2586,8 +2586,8 @@ export async function getEarliestUnclosedMonth(): Promise<string | null> {
 
   const monthOptions = buildRollingMonthOptions(12);
 
-  // Check months from oldest to newest to find the first unclosed month
-  for (let i = monthOptions.length - 1; i >= 0; i--) {
+  // Check months from newest to oldest to find the most recent unclosed month
+  for (let i = 0; i < monthOptions.length; i++) {
     const monthKey = monthOptions[i].value;
     try {
       const closeDoc = await getMonthlyCloseRecord(serverClient, monthKey);


### PR DESCRIPTION
Changed getEarliestUnclosedMonth to check months from newest to oldest instead of oldest to newest. Now returns the most recent unclosed month.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)