### PR TITLE
feat: Phase 1 - Open registration, workspaces, and dynamic sidebar notifications

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { ReactNode } from "react";
 import { Sidebar } from "@financelab/ui";
-import { getNavItems } from "../../lib/data";
+import { getNavItems, getSidebarMonthlyCloseStatus } from "../../lib/data";
 import AuthGate from "./authGate";
 import TopbarWithUser from "./TopbarWithUser";
 import { AuthProvider } from "../../lib/auth-context";
@@ -16,14 +16,17 @@ type ShellLayoutProps = {
 };
 
 export default async function ShellLayout({ children }: ShellLayoutProps) {
-  const navItems = await getNavItems();
+  const [navItems, monthlyCloseStatus] = await Promise.all([
+    getNavItems(),
+    getSidebarMonthlyCloseStatus()
+  ]);
 
   return (
     <AuthProvider>
       <WorkspaceProvider>
         <NumberVisibilityProvider>
           <div className="app-shell">
-            <Sidebar navItems={navItems} />
+            <Sidebar navItems={navItems} monthlyCloseData={monthlyCloseStatus} />
             <main className="main">
               <Suspense fallback={<div className="topbar" />}>
                 <TopbarWithUser />

--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -2787,3 +2787,32 @@ export async function buildMonthlySnapshotPayload(
     asset_class_totals: JSON.stringify(assetClassTotals)
   };
 }
+
+export async function getSidebarMonthlyCloseStatus(): Promise<{
+  unresolvedCount: number;
+  monthKey: string;
+} | null> {
+  try {
+    // Get the earliest unclosed month
+    const monthKey = await getEarliestUnclosedMonth();
+    if (!monthKey) {
+      return null;
+    }
+
+    // Get the monthly close summary for that month
+    const summary = await getMonthlyCloseSummary(monthKey);
+
+    // Count items with "attention" status
+    const unresolvedCount = summary.checklist.filter(
+      (item) => item.status === "attention"
+    ).length;
+
+    return {
+      unresolvedCount,
+      monthKey
+    };
+  } catch (error) {
+    // Return null on error to prevent layout crash
+    return null;
+  }
+}

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -11,9 +11,13 @@ type NavItem = {
 
 type SidebarProps = {
   navItems: NavItem[];
+  monthlyCloseData?: {
+    unresolvedCount: number;
+    monthKey: string;
+  } | null;
 };
 
-export function Sidebar({ navItems }: SidebarProps) {
+export function Sidebar({ navItems, monthlyCloseData }: SidebarProps) {
   const pathname = usePathname();
 
   return (
@@ -36,13 +40,21 @@ export function Sidebar({ navItems }: SidebarProps) {
           </Link>
         ))}
       </nav>
-      <div className="rail-card">
-        <div className="rail-card-title">Monthly Close</div>
-        <div className="rail-card-body">3 unresolved items</div>
-        <button className="ghost-btn" type="button">
-          Open checklist
-        </button>
-      </div>
+      {monthlyCloseData && (
+        <div className="rail-card">
+          <div className="rail-card-title">Monthly Close</div>
+          <div className="rail-card-body">
+            {monthlyCloseData.unresolvedCount > 0
+              ? `${monthlyCloseData.unresolvedCount} unresolved item${monthlyCloseData.unresolvedCount === 1 ? "" : "s"}`
+              : "Ready to close month"}
+          </div>
+          <Link className="ghost-btn" href="/reports">
+            {monthlyCloseData.unresolvedCount > 0
+              ? "Open checklist"
+              : "Close Month"}
+          </Link>
+        </div>
+      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
This PR implements Phase 1 features including:
- Open registration system with workspace activation
- Dynamic sidebar Monthly Close notification
- Workspace management infrastructure

## Changes

### Open Registration & Workspace System
- Add `/signup` route with self-service registration
- Add `/onboarding` flow for workspace activation
- Implement workspace context and management service
- Add workspace API endpoints for creation and retrieval
- Update authentication flows to support workspace selection
- Add setup script for default workspace initialization

### Dynamic Sidebar Monthly Close Notification
- Implement real-time unresolved item count from monthly close checklist
- Dynamic button text based on status ("Open checklist" vs "Close Month")
- Navigation to `/reports` page on click
- Hide notification when no unclosed months exist
- Synchronize data with `/reports` page for consistency

### API & Auth Improvements
- Refactor API routes to use new authentication helper
- Add workspace-aware API authentication
- Simplify auth checks across all API endpoints

## Test Plan
- [x] Signup flow creates user and workspace
- [x] Onboarding activates workspace correctly
- [x] Sidebar shows correct unresolved count matching `/reports` page
- [x] Button text changes appropriately based on checklist status
- [x] Clicking button navigates to `/reports`
- [x] No rail-card shown when all months are closed
- [x] Build succeeds with no TypeScript errors

## Files Modified
- 29 files changed, 1498 insertions(+), 388 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)