### PR TITLE
fix: support Appwrite Cloud authentication with Authorization headers

### DIFF
--- a/apps/web/app/onboarding/OnboardingClient.tsx
+++ b/apps/web/app/onboarding/OnboardingClient.tsx
@@ -73,9 +73,21 @@ export default function OnboardingClient() {
     setStatusMessage(null);
 
     try {
+      // Get the current session token
+      const appwrite = getAppwriteClient();
+      if (!appwrite) {
+        throw new Error("Appwrite client not available");
+      }
+
+      const account = new Account(appwrite.client);
+      const session = await account.getSession("current");
+
       const response = await fetch("/api/workspaces", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.secret}`
+        },
         body: JSON.stringify({
           name: finalName,
           currency


### PR DESCRIPTION
Updated authentication system to work with both Appwrite Cloud and self-hosted instances by supporting session tokens via Authorization headers in addition to cookies. This fixes the 401 Unauthorized error when creating workspaces.

Changes:
- Modified getCurrentUser functions to check Authorization header first, then fall back to cookies
- Updated client-side code to send session tokens in API requests
- Applied fix to both workspace routes and shared api-auth module