### PR TITLE
fix: security and data integrity fixes from code review

### DIFF
--- a/apps/web/app/api/account/export/route.ts
+++ b/apps/web/app/api/account/export/route.ts
@@ -3,6 +3,7 @@ import { Query } from "node-appwrite";
 import { getApiContext, getServerConfig, createDatabasesClient } from "../../../../lib/api-auth";
 import { COLLECTIONS } from "../../../../lib/collection-names";
 import { rateLimit, DATA_RATE_LIMITS } from "../../../../lib/rate-limit";
+import { writeAuditLog, getClientIp } from "../../../../lib/audit";
 
 export const dynamic = "force-dynamic";
 
@@ -135,6 +136,17 @@ export async function GET(request: Request) {
     }
 
     exportData.workspaces = workspaces;
+
+    writeAuditLog(databases, databaseId, {
+      workspace_id: ctx.user.$id, // export spans all workspaces; use userId as resource scope
+      user_id: ctx.user.$id,
+      action: "export",
+      resource_type: "account",
+      resource_id: ctx.user.$id,
+      summary: `User exported all account data (${workspaceIds.length} workspace(s))`,
+      metadata: { workspaceCount: workspaceIds.length },
+      ip_address: getClientIp(request),
+    });
 
     return new NextResponse(JSON.stringify(exportData, null, 2), {
       status: 200,

--- a/apps/web/app/api/assets/values/route.ts
+++ b/apps/web/app/api/assets/values/route.ts
@@ -96,30 +96,38 @@ export async function POST(request: Request) {
     const workspace = await getWorkspaceById(workspaceId);
     const homeCurrency = workspace?.currency ?? "AUD";
 
-    let created = 0;
+    // Collect the distinct currencies needed across all valid items
+    const validItems = items.filter(
+      (item) => item.assetName && Number.isFinite(item.value)
+    );
+    const distinctCurrencies = [
+      ...new Set(validItems.map((item) => (item.currency ?? homeCurrency).toUpperCase()))
+    ];
+
+    // Pre-fetch ALL FX rates before any writes — fail early if any rate is unavailable
     const rateCache = new Map<string, { rate: number; source: string }>();
-    for (const item of items) {
-      if (!item.assetName || !Number.isFinite(item.value)) {
-        continue;
-      }
-      const currency = (item.currency ?? homeCurrency).toUpperCase();
-      let rate = rateCache.get(currency);
-      if (!rate) {
-        try {
-          rate = await fetchHomeCurrencyRate(currency, homeCurrency);
-        } catch (error) {
-          return NextResponse.json(
-            {
-              detail:
-                error instanceof Error
-                  ? error.message
-                  : `Unable to fetch FX rate for ${currency}.`
-            },
-            { status: 502 }
-          );
-        }
+    for (const currency of distinctCurrencies) {
+      try {
+        const rate = await fetchHomeCurrencyRate(currency, homeCurrency);
         rateCache.set(currency, rate);
+      } catch (error) {
+        return NextResponse.json(
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : `Unable to fetch FX rate for ${currency}.`
+          },
+          { status: 502 }
+        );
       }
+    }
+
+    // All rates available — now write all documents
+    let created = 0;
+    for (const item of validItems) {
+      const currency = (item.currency ?? homeCurrency).toUpperCase();
+      const rate = rateCache.get(currency)!;
       const homeValue = item.value * rate.rate;
       await databases.createDocument(config.databaseId, "asset_values", ID.unique(), {
         workspace_id: workspaceId,

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
     } catch (sessionError: unknown) {
       const err = sessionError as { code?: number; type?: string; message?: string };
       return NextResponse.json(
-        { error: "Invalid credentials", detail: err.message },
+        { error: "Invalid credentials" },
         { status: 401 }
       );
     }
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
   } catch (error: unknown) {
     const err = error as { code?: number; type?: string; message?: string };
     return NextResponse.json(
-      { error: "Invalid credentials", detail: err.message },
+      { error: "Invalid credentials" },
       { status: 401 }
     );
   }

--- a/apps/web/app/api/cash-logs/commit/route.ts
+++ b/apps/web/app/api/cash-logs/commit/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
     const workspaceCategories = await getCategoriesWithMeta(workspaceId);
 
     for (const group of processedGroups) {
-      // Fetch the original log to get the date
+      // Fetch the original log to get the date and check idempotency
       let logDate: string;
       let logIsIncome = false;
 
@@ -54,6 +54,11 @@ export async function POST(request: Request) {
           "cash_logs",
           group.logId
         );
+        // Idempotency guard: skip logs already committed
+        if (logDoc.status === "committed") {
+          updatedLogs.push(group.logId);
+          continue;
+        }
         logDate = String(logDoc.date ?? new Date().toISOString().split("T")[0]);
         logIsIncome = Boolean(logDoc.isIncome);
       } catch {

--- a/apps/web/app/api/categories/[id]/route.ts
+++ b/apps/web/app/api/categories/[id]/route.ts
@@ -76,7 +76,19 @@ export async function PATCH(request: Request, context: RouteContext) {
 
     let renamedCount = 0;
 
-    // Handle rename
+    // Build the update payload first
+    const updatePayload: Record<string, string> = {};
+    if (newName && newName !== currentName) {
+      updatePayload.name = newName;
+    }
+    if (newGroup !== undefined && (newGroup === "income" || newGroup === "expense")) {
+      updatePayload.group = newGroup;
+    }
+    if (newColor !== undefined) {
+      updatePayload.color = newColor;
+    }
+
+    // Handle rename: validate, then update category document FIRST, then transactions
     if (newName && newName !== currentName) {
       if (isSystemCategory(newName)) {
         return NextResponse.json(
@@ -100,6 +112,16 @@ export async function PATCH(request: Request, context: RouteContext) {
         return NextResponse.json(
           { error: "A category with this name already exists" },
           { status: 409 }
+        );
+      }
+
+      // Update the category document first so it's consistent before touching transactions
+      if (Object.keys(updatePayload).length > 0) {
+        await databases.updateDocument(
+          config.databaseId,
+          COLLECTIONS.CATEGORIES,
+          id,
+          updatePayload
         );
       }
 
@@ -134,21 +156,8 @@ export async function PATCH(request: Request, context: RouteContext) {
         if (batch.documents.length < BATCH_SIZE) break;
         cursor = batch.documents[batch.documents.length - 1].$id;
       }
-    }
-
-    // Build the update payload
-    const updatePayload: Record<string, string> = {};
-    if (newName && newName !== currentName) {
-      updatePayload.name = newName;
-    }
-    if (newGroup !== undefined && (newGroup === "income" || newGroup === "expense")) {
-      updatePayload.group = newGroup;
-    }
-    if (newColor !== undefined) {
-      updatePayload.color = newColor;
-    }
-
-    if (Object.keys(updatePayload).length > 0) {
+    } else if (Object.keys(updatePayload).length > 0) {
+      // No rename — just update group/color on category document
       await databases.updateDocument(
         config.databaseId,
         COLLECTIONS.CATEGORIES,

--- a/apps/web/app/api/imports/route.ts
+++ b/apps/web/app/api/imports/route.ts
@@ -286,7 +286,7 @@ export async function POST(request: Request) {
     source_owner: sourceOwner ?? "",
     file_name: fileName ?? "",
     row_count: rows.length,
-    status: "imported",
+    status: "pending",
     uploaded_at: new Date().toISOString()
   };
 
@@ -298,48 +298,61 @@ export async function POST(request: Request) {
   const workspaceCurrency = workspace?.currency ?? "AUD";
   const referenceDate = getReferenceDate(rows);
 
-  for (const row of rows) {
-    const amount = row.amount ?? "";
-    const direction = amount.startsWith("-") ? "debit" : "credit";
-    const rawCategory = row.category?.trim() ?? "";
-    const category =
-      !rawCategory || rawCategory.toLowerCase() === "unknown"
-        ? "Uncategorised"
-        : rawCategory;
-    const transactionId = ID.unique();
-    const normalizedDate = normalizeDateToISO(row.date ?? "");
-    const transactionDoc = {
-      workspace_id: workspaceId,
-      import_id: importId,
-      date: normalizedDate,
-      description: row.description ?? "",
-      amount,
-      currency: row.currency ?? workspaceCurrency,
-      account_name: row.account ?? sourceAccount ?? "Unassigned",
-      source_account: sourceAccount ?? "",
-      source_owner: sourceOwner ?? "",
-      category_name: category,
-      direction,
-      notes: "",
-      is_transfer: category === "Transfer",
-      needs_review: category === "Uncategorised"
-    };
+  const BATCH_SIZE = 25;
+  for (let batchStart = 0; batchStart < rows.length; batchStart += BATCH_SIZE) {
+    const batch = rows.slice(batchStart, batchStart + BATCH_SIZE);
+    const batchInputs = batch.map((row) => {
+      const amount = row.amount ?? "";
+      const direction = amount.startsWith("-") ? "debit" : "credit";
+      const rawCategory = row.category?.trim() ?? "";
+      const category =
+        !rawCategory || rawCategory.toLowerCase() === "unknown"
+          ? "Uncategorised"
+          : rawCategory;
+      const transactionId = ID.unique();
+      const normalizedDate = normalizeDateToISO(row.date ?? "");
+      return {
+        transactionId,
+        normalizedDate,
+        amount,
+        direction,
+        category,
+        description: row.description ?? "",
+        account: row.account ?? sourceAccount ?? "Unassigned",
+        doc: {
+          workspace_id: workspaceId,
+          import_id: importId,
+          date: normalizedDate,
+          description: row.description ?? "",
+          amount,
+          currency: row.currency ?? workspaceCurrency,
+          account_name: row.account ?? sourceAccount ?? "Unassigned",
+          source_account: sourceAccount ?? "",
+          source_owner: sourceOwner ?? "",
+          category_name: category,
+          direction,
+          notes: "",
+          is_transfer: category === "Transfer",
+          needs_review: category === "Uncategorised"
+        }
+      };
+    });
 
-    await databases.createDocument(
-      config.databaseId,
-      "transactions",
-      transactionId,
-      transactionDoc
+    await Promise.all(
+      batchInputs.map(({ transactionId, doc }) =>
+        databases.createDocument(config.databaseId, "transactions", transactionId, doc)
+      )
     );
 
-    createdTransactions.push({
-      id: transactionId,
-      date: normalizedDate,
-      description: row.description ?? "",
-      amount,
-      account: row.account ?? sourceAccount ?? "Unassigned"
-    });
+    for (const { transactionId, normalizedDate, amount, description, account } of batchInputs) {
+      createdTransactions.push({ id: transactionId, date: normalizedDate, description, amount, account });
+    }
   }
+
+  // Mark the import as fully complete now that all transactions are written
+  await databases.updateDocument(config.databaseId, "imports", importId, {
+    status: "imported",
+  });
 
   const shouldAutoCategorize = rows.every((row) => {
     const rawCategory = row.category?.trim();

--- a/apps/web/app/api/monthly-close/route.ts
+++ b/apps/web/app/api/monthly-close/route.ts
@@ -128,74 +128,88 @@ export async function POST(request: Request) {
     const month = parsed.data!.month;
 
     const snapshotPayload = await buildMonthlySnapshotPayload(workspaceId, month);
-  if (!snapshotPayload) {
-    return NextResponse.json(
-      { error: "Unable to build monthly snapshot." },
-      { status: 500 }
-    );
-  }
+    if (!snapshotPayload) {
+      return NextResponse.json(
+        { error: "Unable to build monthly snapshot." },
+        { status: 500 }
+      );
+    }
 
-  let snapshot;
-  try {
-    snapshot = await createMonthlySnapshot(
-      databases,
-      config.databaseId,
-      snapshotPayload
-    );
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unable to create snapshot.";
-    const attributes = await listCollectionAttributes(
-      databases,
-      config.databaseId,
-      "monthly_snapshots"
-    );
-    const pendingAttributes = (attributes ?? []).filter(
-      (attr) => attr.status && attr.status !== "available"
-    );
-    console.error("Monthly close snapshot failed.", {
-      message,
-      databaseId: config.databaseId,
-      projectId: config.projectId,
-      attributes,
-      pendingAttributes
-    });
-    return NextResponse.json(
-      {
-        detail: message,
-        hint: getSchemaHintMessage(config.databaseId, config.projectId),
+    // Step 1: Create or update the monthly_closes record FIRST (before snapshot)
+    // so the close intent is recorded even if snapshot creation fails.
+    const existing = await getCloseDocument(databases, config.databaseId, workspaceId, month);
+    const closePayload = {
+      workspace_id: workspaceId,
+      month,
+      status: "closed",
+      closed_at: new Date().toISOString(),
+      closed_by: "system",
+      notes: parsed.data!.notes ?? "",
+      snapshot_id: "" // will be updated after snapshot is created
+    };
+
+    let closeDocId: string;
+    if (existing) {
+      await databases.updateDocument(
+        config.databaseId,
+        "monthly_closes",
+        String(existing.$id),
+        closePayload
+      );
+      closeDocId = String(existing.$id);
+    } else {
+      const closeDoc = await databases.createDocument(
+        config.databaseId,
+        "monthly_closes",
+        ID.unique(),
+        closePayload
+      );
+      closeDocId = String(closeDoc.$id);
+    }
+
+    // Step 2: Create the snapshot document
+    let snapshot;
+    try {
+      snapshot = await createMonthlySnapshot(
+        databases,
+        config.databaseId,
+        snapshotPayload
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to create snapshot.";
+      const attributes = await listCollectionAttributes(
+        databases,
+        config.databaseId,
+        "monthly_snapshots"
+      );
+      const pendingAttributes = (attributes ?? []).filter(
+        (attr) => attr.status && attr.status !== "available"
+      );
+      console.error("Monthly close snapshot failed.", {
+        message,
+        databaseId: config.databaseId,
+        projectId: config.projectId,
         attributes,
         pendingAttributes
-      },
-      { status: 500 }
-    );
-  }
+      });
+      return NextResponse.json(
+        {
+          detail: message,
+          hint: getSchemaHintMessage(config.databaseId, config.projectId),
+          attributes,
+          pendingAttributes
+        },
+        { status: 500 }
+      );
+    }
 
-  const existing = await getCloseDocument(databases, config.databaseId, workspaceId, month);
-  const updatePayload = {
-    workspace_id: workspaceId,
-    month,
-    status: "closed",
-    closed_at: new Date().toISOString(),
-    closed_by: "system",
-    notes: parsed.data!.notes ?? "",
-    snapshot_id: String(snapshot.$id ?? "")
-  };
-
-  if (existing) {
+    // Step 3: Update the monthly_closes record with the real snapshot_id
     await databases.updateDocument(
       config.databaseId,
       "monthly_closes",
-      String(existing.$id),
-      updatePayload
+      closeDocId,
+      { snapshot_id: String(snapshot.$id ?? "") }
     );
-  } else {
-    await databases.createDocument(
-      config.databaseId,
-      "monthly_closes",
-      ID.unique(),
-      updatePayload
-    );
-  }
 
     // Fire-and-forget audit log
     writeAuditLog(databases, config.databaseId, {

--- a/apps/web/lib/__tests__/validations.test.ts
+++ b/apps/web/lib/__tests__/validations.test.ts
@@ -319,14 +319,22 @@ describe("InvitationCreateSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("validates all four roles", () => {
-    for (const role of ["owner", "admin", "editor", "viewer"]) {
+  it("validates all three roles (owner excluded from invitations)", () => {
+    for (const role of ["admin", "editor", "viewer"]) {
       const result = InvitationCreateSchema.safeParse({
         email: "u@e.com",
         role,
       });
       expect(result.success).toBe(true);
     }
+  });
+
+  it("rejects owner role in invitations", () => {
+    const result = InvitationCreateSchema.safeParse({
+      email: "u@e.com",
+      role: "owner",
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/apps/web/lib/invitation-service.ts
+++ b/apps/web/lib/invitation-service.ts
@@ -3,14 +3,14 @@ import { Query, ID } from "node-appwrite";
 import { COLLECTIONS } from "./collection-names";
 import type { WorkspaceMemberRole } from "./workspace-types";
 
-if (process.env.NODE_ENV === "production" && !process.env.INVITATION_SECRET) {
+if (!process.env.INVITATION_SECRET) {
   throw new Error(
     "FATAL: INVITATION_SECRET environment variable is not set. " +
-    "Set INVITATION_SECRET to a random secret string before running in production."
+    "Set INVITATION_SECRET to a random secret string before running."
   );
 }
 
-const INVITATION_SECRET = process.env.INVITATION_SECRET || "default-invitation-secret-dev-only";
+const INVITATION_SECRET = process.env.INVITATION_SECRET;
 const INVITATION_EXPIRY_DAYS = 7;
 
 export type WorkspaceInvitation = {

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -215,8 +215,10 @@ export async function rateLimit(
   const store = getStore();
 
   // Use forwarded IP, then fall back to a generic key
+  const realIp = request.headers.get("x-real-ip")?.trim();
   const forwarded = request.headers.get("x-forwarded-for");
-  const ip = forwarded?.split(",")[0]?.trim() || "unknown";
+  const forwardedSegments = forwarded?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+  const ip = realIp || forwardedSegments[forwardedSegments.length - 1] || "unknown";
   const key = `${ip}:${new URL(request.url).pathname}`;
 
   try {

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -10,15 +10,15 @@ export interface SessionData {
   csrfToken: string; // CSRF synchronizer token
 }
 
-// Fail-fast if SESSION_SECRET is not set in production
-if (process.env.NODE_ENV === "production" && !process.env.SESSION_SECRET) {
+// Fail-fast if SESSION_SECRET is not set in any environment
+if (!process.env.SESSION_SECRET) {
   throw new Error(
     "FATAL: SESSION_SECRET environment variable is not set. " +
-    "Set SESSION_SECRET to a random 32+ character string before running in production."
+    "Set SESSION_SECRET to a random 32+ character string before running."
   );
 }
 
-const SESSION_PASSWORD = process.env.SESSION_SECRET || "complex_password_at_least_32_characters_long_for_dev_only";
+const SESSION_PASSWORD = process.env.SESSION_SECRET;
 
 export const sessionOptions: SessionOptions = {
   password: SESSION_PASSWORD,

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -215,7 +215,7 @@ export const WorkspaceSwitchSchema = z.object({
 
 export const InvitationCreateSchema = z.object({
   email: trimmedString.min(1, "Email is required").email("Invalid email"),
-  role: z.enum(["owner", "admin", "editor", "viewer"]),
+  role: z.enum(["admin", "editor", "viewer"]),
 });
 
 export const InvitationAcceptSchema = z.object({

--- a/apps/web/lib/workspace-context.tsx
+++ b/apps/web/lib/workspace-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from 'react';
 import { useAuth } from './auth-context';
+import { apiFetch } from './api-fetch';
 
 export interface Workspace {
   id: string;
@@ -103,7 +104,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     currency: string = 'AUD'
   ): Promise<Workspace | null> => {
     try {
-      const response = await fetch('/api/workspaces', {
+      const response = await apiFetch('/api/workspaces', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -118,7 +119,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(`Failed to create workspace: ${response.status} ${errorData.detail || response.statusText}`);
+        throw new Error(`Failed to create workspace: ${response.status} ${errorData.error || response.statusText}`);
       }
 
       const data = await response.json();

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     include: ["**/__tests__/**/*.test.{ts,tsx}"],
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
+    env: {
+      SESSION_SECRET: "test-session-secret-32-chars-minimum-pad",
+      INVITATION_SECRET: "test-invitation-secret-value",
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Implements 13 security and data integrity fixes identified in the automated code review.

### Security
- Remove `'owner'` from `InvitationCreateSchema` — prevents workspace admins from creating owner-level accounts via invitation
- Fix rate limiter IP extraction — use `x-real-ip` (Vercel-injected, not client-controllable) instead of leftmost `X-Forwarded-For`
- Remove `detail: err.message` from login error responses — prevents user enumeration via Appwrite error messages
- Make `SESSION_SECRET` and `INVITATION_SECRET` fail-fast unconditionally — eliminates silent fallback to hardcoded strings in staging
- Add audit log to `GET /api/account/export` — bulk data exports are now traceable

### Data Integrity
- **imports/route.ts**: Import doc created with `status: 'pending'` before tx loop; updated to `'imported'` only after all rows succeed. Transactions created in parallel batches of 25 (prevents 500-row timeout)
- **cash-logs/commit**: Idempotency guard — already-committed logs return `{ ok: true }` immediately, preventing duplicate transactions on retry
- **categories/[id] PATCH**: Category document updated first, then transactions — prevents name split-state on failure
- **assets/values POST**: All FX rates pre-fetched before any writes — prevents orphaned partial records
- **monthly-close POST**: `monthly_closes` record created before snapshot — prevents orphaned snapshots

### Frontend
- `workspace-context.tsx`: Replace raw `fetch` with `apiFetch` in `createWorkspace` (was bypassing CSRF middleware, would 403 in production)
- `workspace-context.tsx`: Fix `errorData.detail` → `errorData.error` (error messages were always undefined)

### Deferred (documented in todo)
- Sidebar monthly-close materialization (needs workspace schema change)
- GET /api/accounts dedicated collection (needs data migration)
- Ledger month filter push-to-DB (large data.ts refactor)

## Test plan
- [ ] TypeScript compiles with 0 errors
- [ ] Existing vitest suite passes
- [ ] Invite flow: verify owner role option is gone from UI
- [ ] Login: verify error responses no longer include Appwrite detail
- [ ] Import: test with large CSV (verify no timeout, no orphaned records on error)
- [ ] Cash log: commit twice, verify no duplicate transactions

 Generated with [Claude Code](https://claude.com/claude-code)