### PR TITLE
perf: eliminate 2 sequential Appwrite round-trips from every page nav

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -2,7 +2,6 @@ import { Suspense } from "react";
 import type { ReactNode } from "react";
 import { redirect } from "next/navigation";
 import { getNavItems, getSidebarMonthlyCloseStatus } from "../../lib/data";
-import { getWorkspaceById } from "../../lib/workspace-service";
 import AuthGate from "./authGate";
 import TopbarWithUser from "./TopbarWithUser";
 import AppShell from "./AppShell";
@@ -30,13 +29,10 @@ export default async function ShellLayout({ children }: ShellLayoutProps) {
     redirect("/login");
   }
 
-  // Fetch workspace to get home currency
-  const workspace = await getWorkspaceById(context.workspaceId);
-  const homeCurrency = workspace?.currency ?? "AUD";
+  // currency is now returned directly from getApiContext (no extra DB call needed)
+  const homeCurrency = context.currency;
 
   // Fetch nav items and sidebar status in parallel
-  // getNavItems() is a static return so it's instant, but we parallelize
-  // getSidebarMonthlyCloseStatus to avoid sequential await chains.
   const [navItems, monthlyCloseStatus] = await Promise.all([
     getNavItems({ isSuperadmin: isSuperadmin(context.user.labels) }),
     getSidebarMonthlyCloseStatus(context.workspaceId, homeCurrency),

--- a/apps/web/app/api/admin/suggestions/[id]/__tests__/route.test.ts
+++ b/apps/web/app/api/admin/suggestions/[id]/__tests__/route.test.ts
@@ -17,6 +17,7 @@ const mockCtx = {
   role: "owner" as const,
   plan: "free",
   featureOverrides: "[]",
+  currency: "AUD",
 };
 
 const mockAccount = { get: vi.fn() };

--- a/apps/web/app/api/admin/suggestions/__tests__/route.test.ts
+++ b/apps/web/app/api/admin/suggestions/__tests__/route.test.ts
@@ -18,6 +18,7 @@ const mockCtx = {
   role: "owner" as const,
   plan: "free",
   featureOverrides: "[]",
+  currency: "AUD",
 };
 
 const mockAccount = { get: vi.fn() };

--- a/apps/web/app/api/suggestions/[id]/__tests__/route.test.ts
+++ b/apps/web/app/api/suggestions/[id]/__tests__/route.test.ts
@@ -20,6 +20,7 @@ const mockContext = {
   role: "owner" as const,
   plan: "free",
   featureOverrides: "[]",
+  currency: "AUD",
 };
 
 const makeRouteContext = (id = "suggestion-1") => ({

--- a/apps/web/app/api/suggestions/__tests__/route.test.ts
+++ b/apps/web/app/api/suggestions/__tests__/route.test.ts
@@ -19,6 +19,7 @@ const mockContext = {
   role: "owner" as const,
   plan: "free",
   featureOverrides: "[]",
+  currency: "AUD",
 };
 
 beforeEach(async () => {

--- a/apps/web/app/api/transactions/__tests__/route.test.ts
+++ b/apps/web/app/api/transactions/__tests__/route.test.ts
@@ -21,6 +21,7 @@ const mockContext = {
   role: "owner" as const,
   plan: "free",
   featureOverrides: "[]",
+  currency: "AUD",
 };
 
 beforeEach(async () => {

--- a/apps/web/lib/api-auth.ts
+++ b/apps/web/lib/api-auth.ts
@@ -119,16 +119,24 @@ export const getApiContext = cache(async (): Promise<ApiContext | null> => {
     }
   }
 
-  // 5. Use API key client to validate workspace membership
+  // 5+6. Validate workspace membership and fetch workspace doc in parallel
+  // (both only need activeWorkspaceId, which is now known)
   const adminDatabases = createDatabasesClient(config);
-  const membership = await adminDatabases.listDocuments(
-    config.databaseId,
-    COLLECTIONS.WORKSPACE_MEMBERS,
-    [
-      Query.equal('user_id', user.$id),
-      Query.equal('workspace_id', activeWorkspaceId),
-    ]
-  );
+  const [membership, workspaceDoc] = await Promise.all([
+    adminDatabases.listDocuments(
+      config.databaseId,
+      COLLECTIONS.WORKSPACE_MEMBERS,
+      [
+        Query.equal('user_id', user.$id),
+        Query.equal('workspace_id', activeWorkspaceId),
+      ]
+    ),
+    adminDatabases.getDocument(
+      config.databaseId,
+      COLLECTIONS.WORKSPACES,
+      activeWorkspaceId
+    ),
+  ]);
 
   if (membership.documents.length === 0) {
     throw new Error('User not member of active workspace');
@@ -142,13 +150,6 @@ export const getApiContext = cache(async (): Promise<ApiContext | null> => {
     });
     throw new Error('Data integrity error: duplicate memberships');
   }
-
-  // 6. Fetch workspace document to get plan data
-  const workspaceDoc = await adminDatabases.getDocument(
-    config.databaseId,
-    COLLECTIONS.WORKSPACES,
-    activeWorkspaceId
-  );
 
   // 7. Return context with API key databases client (for data access)
   return {
@@ -164,6 +165,7 @@ export const getApiContext = cache(async (): Promise<ApiContext | null> => {
     role: membership.documents[0].role as WorkspaceMemberRole,
     plan: (workspaceDoc.plan as string) || "free",
     featureOverrides: (workspaceDoc.feature_overrides as string) || "[]",
+    currency: (workspaceDoc.currency as string) || "AUD",
     databases: adminDatabases,
   };
 });

--- a/apps/web/lib/workspace-types.ts
+++ b/apps/web/lib/workspace-types.ts
@@ -52,6 +52,7 @@ export interface ApiContext {
   role: WorkspaceMemberRole;
   plan: string;
   featureOverrides: string;
+  currency: string;
   databases: any; // Databases type from node-appwrite
 }
 


### PR DESCRIPTION
## Problem

Every authenticated page navigation was running 5+ sequential Appwrite network calls before rendering anything, causing the 2-3 second delay.

## Root cause

Two issues in the critical path:

**1. Sequential membership + workspace fetch in `getApiContext`**
`listDocuments(WORKSPACE_MEMBERS)` and `getDocument(WORKSPACES)` were running sequentially, but both only need `activeWorkspaceId` (known after `account.getPrefs`). One was idle while the other ran.

**2. Redundant `getWorkspaceById` call in the layout**
`getApiContext` already fetches the workspace document to read `plan` and `featureOverrides`. The layout then called `getWorkspaceById` again (a second `getDocument` for the same record) just to get `homeCurrency`.

## Fix

1. Parallelise membership check + workspace fetch in `getApiContext` with `Promise.all`
2. Add `currency` to `ApiContext`, return it from `getApiContext`
3. Remove `getWorkspaceById` from the layout — use `context.currency` directly

## Before vs after

```
Before: session → [user, prefs] → membership → workspace → getWorkspaceById → [nav, sidebar]
After:  session → [user, prefs] → [membership, workspace] → [nav, sidebar]
```

Saves ~2 sequential Appwrite round-trips (~300-600ms) per page navigation.

## Verification
- TypeScript: 0 errors
- Tests: 412/412 pass
- 5 test files updated to include `currency: "AUD"` in mock ApiContext objects